### PR TITLE
Rename root DNS record and update alias target.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -207,14 +207,13 @@ resource "aws_route53_record" "www" {
   }
 }
 
-# Create Route 53 DNS record for the root domain
-resource "aws_route53_record" "root" {
+resource "aws_route53_record" "root_redirect" {
   zone_id = data.aws_route53_zone.existing_zone.zone_id
   name    = var.domain
   type    = "A"
   alias {
-    name                   = aws_cloudfront_distribution.static_website.domain_name
-    zone_id                = aws_cloudfront_distribution.static_website.hosted_zone_id
+    name                   = aws_route53_record.www.name
+    zone_id                = aws_route53_record.www.zone_id
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
Renamed the Route 53 DNS record resource for clarity and updated its alias target to point to the 'www' record instead of the CloudFront distribution. This improves logical consistency and simplifies domain redirection setup.