### PR TITLE
Expand DNS record alias target to include root domain.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -331,13 +331,13 @@ resource "aws_route53_record" "www" {
   }
 }
 
-resource "aws_route53_record" "root_redirect" {
+resource "aws_route53_record" "root" {
   zone_id = data.aws_route53_zone.existing_zone.zone_id
   name    = var.domain
   type    = "A"
   alias {
-    name                   = aws_route53_record.www.name
-    zone_id                = aws_route53_record.www.zone_id
+    name                   = aws_cloudfront_distribution.static_website.domain_name
+    zone_id                = aws_cloudfront_distribution.static_website.hosted_zone_id
     evaluate_target_health = false
   }
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -3,4 +3,4 @@ AWS_ACCOUNT_ID = "123456789012" /*Replace with Account ID*/
 AWS_ROLE_ARN = "arn:aws:iam::123456789012:role/TerraformExecutionRole"
 
 domain = "pedrollanca.com"
-acm_subject_alternative_names = ["www.pedrollanca.com"]
+acm_subject_alternative_names = ["pedrollanca.com", "www.pedrollanca.com"]


### PR DESCRIPTION
Updated Route 53 root DNS record alias target to point directly to the CloudFront distribution. Adjusted subject alternative names in ACM certificate to cover both 'pedrollanca.com' and 'www.pedrollanca.com'.