### PR TITLE
Fix Route 53 record loop key for SSL certificate validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,7 @@ resource "aws_acm_certificate" "ssl_certificate" {
 # Validate domain ownership for the SSL certificate
 resource "aws_route53_record" "certificate_validation" {
   for_each = {
-    for dvo in aws_acm_certificate.ssl_certificate.domain_validation_options : dvo.domain_name => {
+    for dvo in aws_acm_certificate.ssl_certificate.domain_validation_options : dvo.resource_record_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type


### PR DESCRIPTION
Corrected the `for_each` loop key in the `aws_route53_record` resource from `domain_name` to `resource_record_name` to ensure proper mapping of domain validation options.