### PR TITLE
Ensure proper handling of domain validation options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,7 @@ resource "aws_acm_certificate" "ssl_certificate" {
 # Validate domain ownership for the SSL certificate
 resource "aws_route53_record" "certificate_validation" {
   for_each = {
-    for dvo in aws_acm_certificate.ssl_certificate.domain_validation_options : dvo.resource_record_name => {
+    for dvo in toset(aws_acm_certificate.ssl_certificate.domain_validation_options) : dvo.resource_record_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type


### PR DESCRIPTION
Updated the `for_each` expression in the `aws_route53_record` resource to use `toset` for correctly processing `domain_validation_options`.